### PR TITLE
[review] Ruby 新バージョン検知 PR を自動作成するワークフローを追加

### DIFF
--- a/.github/workflows/add_ruby_versions.yml
+++ b/.github/workflows/add_ruby_versions.yml
@@ -1,0 +1,193 @@
+name: Add new Ruby versions
+
+on:
+  schedule:
+    # 毎日 09:00 JST = 00:00 UTC
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  add_ruby_versions:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Fetch all bare-semver tags from Docker Hub library/ruby
+        id: fetch
+        env:
+          MAX_PAGES: 50
+        run: |
+          set -euo pipefail
+          tmp_all="$(mktemp)"
+          url="https://hub.docker.com/v2/repositories/library/ruby/tags/?page_size=100"
+          page=0
+          while [[ -n "${url}" && "${url}" != "null" ]]; do
+            page=$((page + 1))
+            if (( page > MAX_PAGES )); then
+              echo "::error::Exceeded MAX_PAGES=${MAX_PAGES}"
+              exit 1
+            fi
+            echo "Fetching page ${page}: ${url}"
+            resp="$(curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors \
+                      -H 'Accept: application/json' "${url}")"
+            echo "${resp}" | jq -r '.results[].name' >> "${tmp_all}"
+            url="$(echo "${resp}" | jq -r '.next')"
+          done
+
+          grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' "${tmp_all}" \
+            | sort -u > upstream_versions.txt
+          echo "Found $(wc -l < upstream_versions.txt) bare-semver Ruby tags upstream"
+
+      - name: Compute new versions (skip back-fill of gaps) and update ruby_versions.json
+        id: diff
+        working-directory: .github/workflows/
+        run: |
+          set -euo pipefail
+
+          upstream="${{ github.workspace }}/upstream_versions.txt"
+
+          # 採否条件:
+          #   - (major.minor) が現リストにあり、かつ patch > 系列最大パッチ          → 採用
+          #   - (major.minor) が現リストに無く、現リストの最古系列より新しい (major.minor) → 採用（新系列）
+          #   - それ以外（既存・欠番・サポート終了済みの古い系列）                    → 不採用
+          jq -r '.[]' ruby_versions.json > /tmp/current_versions.txt
+
+          python3 - "$upstream" /tmp/current_versions.txt > /tmp/new_versions.txt <<'PY'
+          import sys
+
+          upstream_path, current_path = sys.argv[1], sys.argv[2]
+
+          def parse(v):
+              return tuple(int(x) for x in v.split('.'))
+
+          current = [line.strip() for line in open(current_path) if line.strip()]
+          upstream = [line.strip() for line in open(upstream_path) if line.strip()]
+
+          max_patch = {}
+          for v in current:
+              maj, minr, pat = parse(v)
+              key = (maj, minr)
+              if key not in max_patch or pat > max_patch[key]:
+                  max_patch[key] = pat
+
+          # サポート終了済みの古い系列を自動追加しないため、現リストの最古系列より古い (major,minor) は除外
+          oldest_series = min(max_patch.keys())
+
+          out = []
+          for v in upstream:
+              maj, minr, pat = parse(v)
+              key = (maj, minr)
+              if key in max_patch:
+                  if pat > max_patch[key]:
+                      out.append(v)
+              elif key > oldest_series:
+                  out.append(v)
+
+          for v in sorted(set(out), key=parse):
+              print(v)
+          PY
+
+          if [[ ! -s /tmp/new_versions.txt ]]; then
+            echo "No new Ruby versions to add."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "New versions detected:"
+          cat /tmp/new_versions.txt
+
+          jq -s --rawfile newv /tmp/new_versions.txt '
+            (.[0] + ($newv | split("\n") | map(select(length > 0))))
+            | unique
+            | sort_by(split(".") | map(tonumber))
+            | reverse
+          ' ruby_versions.json > ruby_versions.json.new
+          mv ruby_versions.json.new ruby_versions.json
+
+          new_sorted=$(sort -Vr /tmp/new_versions.txt | paste -sd ', ' -)
+          count=$(wc -l < /tmp/new_versions.txt | tr -d ' ')
+
+          {
+            echo "has_changes=true"
+            echo "new_versions_csv=${new_sorted}"
+            echo "new_versions_count=${count}"
+          } >> "$GITHUB_OUTPUT"
+
+          sort -Vr /tmp/new_versions.txt | sed 's/^/- /' > /tmp/pr_body_versions.txt
+
+      - name: Build PR body
+        if: steps.diff.outputs.has_changes == 'true'
+        id: meta
+        run: |
+          set -euo pipefail
+          csv="${{ steps.diff.outputs.new_versions_csv }}"
+          echo "title=Add Ruby ${csv}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo 'body<<__PR_BODY__'
+            echo "Docker Hub の \`library/ruby\` タグ一覧をもとに、未登録の Ruby バージョンを \`.github/workflows/ruby_versions.json\` に追加します。"
+            echo
+            echo "## 追加バージョン"
+            cat /tmp/pr_body_versions.txt
+            echo
+            echo "## 参照元"
+            echo "- Docker Hub Tags API: https://hub.docker.com/v2/repositories/library/ruby/tags/?page_size=100"
+            echo "- Docker Hub UI: https://hub.docker.com/_/ruby/tags"
+            echo
+            echo "## 抽出ロジック"
+            echo "- 正規表現 \`^[0-9]+\\.[0-9]+\\.[0-9]+\$\` に一致する素 semver タグのみ採用（バリアント・プレリリース除外）"
+            echo "- 各マイナー系列の \"現状最大パッチ\" より大きいもの、もしくはどの系列にも記載がない新系列のみを追加"
+            echo "- 既存エントリは削除・変更せず、新規分のみを追加し semver 降順で整列"
+            echo
+            echo "---"
+            echo "_This PR was generated by \`.github/workflows/add_ruby_versions.yml\` (run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})._"
+            echo '__PR_BODY__'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create Pull Request
+        if: steps.diff.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: automated/add-ruby-versions
+          delete-branch: true
+          base: main
+          commit-message: |
+            Add Ruby ${{ steps.diff.outputs.new_versions_csv }}
+          title: ${{ steps.meta.outputs.title }}
+          body: ${{ steps.meta.outputs.body }}
+          labels: |
+            ruby-version
+            automated
+          add-paths: |
+            .github/workflows/ruby_versions.json
+
+  notify_failure:
+    if: failure()
+    runs-on: ubuntu-latest
+    needs:
+      - add_ruby_versions
+    steps:
+      - uses: SonicGarden/world-notify-action@v1
+        with:
+          token: ${{ secrets.WORLD_NOTIFY_APP_TOKEN }}
+          groupId: ${{ secrets.WORLD_NOTIFY_APP_GROUP_ID }}
+          content: |
+            ${{ github.event.repository.name }} の ${{ github.workflow }} でエラーが発生しました 😱
+
+            詳細はこちら
+            https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
 # ruby-docker-image
 
 https://gallery.ecr.aws/sonicgarden/ruby のソースコードです。
+
+## Ruby バージョン追加の自動化
+
+[.github/workflows/add_ruby_versions.yml](.github/workflows/add_ruby_versions.yml) が毎日 09:00 JST に Docker Hub の `library/ruby` タグ一覧を確認し、未登録のバージョンを [.github/workflows/ruby_versions.json](.github/workflows/ruby_versions.json) に追加する Pull Request を自動作成します。
+
+### 動作仕様
+
+- 対象タグ: `^[0-9]+\.[0-9]+\.[0-9]+$` に一致するもののみ（`-slim`, `-alpine`, `-preview*` などは除外）
+- 追加対象:
+  - 既存のマイナー系列で、現状の最大パッチより新しいもの（例: 3.4 系の最大が 3.4.9 のときに 3.4.10 が出たら追加）
+  - どの系列にも記載がない新マイナー/メジャー系列（例: 3.5.0、5.0.0）
+- **欠番（過去にスキップしたバージョン）は埋めません**。既存エントリも削除・変更しません
+- 並び順: メジャー.マイナー.パッチで数値比較した降順
+- PR ブランチ: `automated/add-ruby-versions`（固定）。新バージョンが追加検知されるたびに同 PR が force-update されます
+- ラベル: `ruby-version`, `automated`
+- マージは**手動レビュー必須**（auto-merge 無効）
+
+### マージ後の動作
+
+PR をマージすると、`build_and_push.yml` が main push をトリガーに新バージョンを含めてビルド・ECR Public push を行います。
+
+### 即時実行したい場合
+
+Actions タブから「Add new Ruby versions」ワークフローを `workflow_dispatch` で実行してください。
+
+### レビュー中に上書きされるのを防ぐ
+
+cron が同ブランチへ force-push するため、レビュー中に手動コミットを追加すると次回 cron 実行で消える可能性があります。レビューで微調整が必要なときは `automated/add-ruby-versions` から別ブランチを切ってそちらをマージしてください。


### PR DESCRIPTION
## Summary

- 新規ワークフロー `.github/workflows/add_ruby_versions.yml` を追加し、Docker Hub の `library/ruby` タグ一覧を毎日 09:00 JST に取得して、未登録の Ruby バージョンを `.github/workflows/ruby_versions.json` に追加する PR を自動作成する
- 欠番（過去にスキップしたバージョン）は埋めず、サポート終了済みの古い系列も自動復活させない。既存マイナー系列の新パッチと、最古系列より新しい新規系列のみを採用
- PR ブランチは `automated/add-ruby-versions` 固定で force-update。`peter-evans/create-pull-request@v7.0.11` を SHA ピンで利用
- 失敗時は既存の `SonicGarden/world-notify-action@v1` で通知
- README.md に運用セクションを追記

## マージ前のチェック

- [x] リポジトリ Settings → Actions → General → Workflow permissions で「Read and write permissions」と「Allow GitHub Actions to create and approve pull requests」を有効化（PR 作成 API の 403 を防ぐ）
  - 元々有効だった

## Test plan

- [x] このブランチをマージ後、Actions タブから `Add new Ruby versions` を `workflow_dispatch` で手動実行
- [x] `automated/add-ruby-versions` ブランチに PR が立ち、`.github/workflows/ruby_versions.json` に新バージョン（現時点では 3.1.7, 3.2.9, 3.2.10, 3.2.11）のみが降順で追加されることを確認
- [x] 古い系列（1.9〜3.0）や欠番（3.2.7, 3.4.0 等）が**追加されない**ことを確認
- [x] 2 回目以降の実行で同 PR が force-update されることを確認（新規 PR が立たないこと）

## ローカル検証ログ

抽出ロジックを 2026-05-13 時点で実行した結果:

```
== Current max patch per (major,minor) ==
  3.1 -> 6, 3.2 -> 8, 3.3 -> 11, 3.4 -> 9, 4.0 -> 4
Oldest current series: 3.1

== New versions to add ==
  3.1.7  [new-patch]
  3.2.9  [new-patch]
  3.2.10 [new-patch]
  3.2.11 [new-patch]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)